### PR TITLE
Renamed PhpIni*() to PhpConfig*()

### DIFF
--- a/bin/check.php
+++ b/bin/check.php
@@ -32,7 +32,7 @@ if (file_exists($autoloader = __DIR__.'/../../../autoload.php')) {
 
 $lineSize = 70;
 $symfonyRequirements = new SymfonyRequirements();
-$iniPath = $symfonyRequirements->getPhpIniConfigPath();
+$iniPath = $symfonyRequirements->getPhpIniPath();
 
 echo_title('Symfony Requirements Checker');
 

--- a/src/PhpConfigRequirement.php
+++ b/src/PhpConfigRequirement.php
@@ -12,11 +12,11 @@
 namespace Symfony\Requirements;
 
 /**
- * Represents a PHP requirement in form of a php.ini configuration.
+ * Represents a requirement in form of a PHP configuration option.
  *
  * @author Tobias Schultze <http://tobion.de>
  */
-class PhpIniRequirement extends Requirement
+class PhpConfigRequirement extends Requirement
 {
     /**
      * Constructor that initializes the requirement.

--- a/src/Requirement.php
+++ b/src/Requirement.php
@@ -14,7 +14,8 @@ namespace Symfony\Requirements;
 /**
  * Represents a single PHP requirement, e.g. an installed extension.
  * It can be a mandatory requirement or an optional recommendation.
- * There is a special subclass, named PhpIniRequirement, to check a php.ini configuration.
+ * There is a special subclass, named PhpConfigRequirement, to check a PHP
+ * configuration option.
  *
  * @author Tobias Schultze <http://tobion.de>
  */

--- a/src/RequirementCollection.php
+++ b/src/RequirementCollection.php
@@ -70,7 +70,7 @@ class RequirementCollection implements \IteratorAggregate
     }
 
     /**
-     * Adds a mandatory requirement in form of a php.ini configuration.
+     * Adds a mandatory requirement in form of a PHP configuration option.
      *
      * @param string        $cfgName           The configuration name used for ini_get()
      * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
@@ -82,13 +82,13 @@ class RequirementCollection implements \IteratorAggregate
      * @param string        $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
      * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
      */
-    public function addPhpIniRequirement($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null)
+    public function addPhpConfigRequirement($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null)
     {
-        $this->add(new PhpIniRequirement($cfgName, $evaluation, $approveCfgAbsence, $testMessage, $helpHtml, $helpText, false));
+        $this->add(new PhpConfigRequirement($cfgName, $evaluation, $approveCfgAbsence, $testMessage, $helpHtml, $helpText, false));
     }
 
     /**
-     * Adds an optional recommendation in form of a php.ini configuration.
+     * Adds an optional recommendation in form of a PHP configuration option.
      *
      * @param string        $cfgName           The configuration name used for ini_get()
      * @param bool|callback $evaluation        Either a boolean indicating whether the configuration should evaluate to true or false,
@@ -100,9 +100,9 @@ class RequirementCollection implements \IteratorAggregate
      * @param string        $helpHtml          The help text formatted in HTML for resolving the problem (when null and $evaluation is a boolean a default help is derived)
      * @param string|null   $helpText          The help text (when null, it will be inferred from $helpHtml, i.e. stripped from HTML tags)
      */
-    public function addPhpIniRecommendation($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null)
+    public function addPhpConfigRecommendation($cfgName, $evaluation, $approveCfgAbsence = false, $testMessage = null, $helpHtml = null, $helpText = null)
     {
-        $this->add(new PhpIniRequirement($cfgName, $evaluation, $approveCfgAbsence, $testMessage, $helpHtml, $helpText, true));
+        $this->add(new PhpConfigRequirement($cfgName, $evaluation, $approveCfgAbsence, $testMessage, $helpHtml, $helpText, true));
     }
 
     /**
@@ -194,14 +194,14 @@ class RequirementCollection implements \IteratorAggregate
     }
 
     /**
-     * Returns whether a php.ini configuration is not correct.
+     * Returns whether a PHP configuration option is not correct.
      *
      * @return bool php.ini configuration problem?
      */
-    public function hasPhpIniConfigIssue()
+    public function hasPhpConfigIssue()
     {
         foreach ($this->requirements as $req) {
-            if (!$req->isFulfilled() && $req instanceof PhpIniRequirement) {
+            if (!$req->isFulfilled() && $req instanceof PhpConfigRequirement) {
                 return true;
             }
         }
@@ -214,7 +214,7 @@ class RequirementCollection implements \IteratorAggregate
      *
      * @return string|false php.ini file path
      */
-    public function getPhpIniConfigPath()
+    public function getPhpIniPath()
     {
         return get_cfg_var('cfg_file_path');
     }

--- a/src/SymfonyRequirements.php
+++ b/src/SymfonyRequirements.php
@@ -68,7 +68,7 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         if (version_compare($installedPhpVersion, '7.0.0', '<')) {
-            $this->addPhpIniRequirement(
+            $this->addPhpConfigRequirement(
                 'date.timezone', true, false,
                 'date.timezone setting must be set',
                 'Set the "<strong>date.timezone</strong>" setting in php.ini<a href="#phpini">*</a> (like Europe/Paris).'
@@ -142,10 +142,10 @@ class SymfonyRequirements extends RequirementCollection
             }
         }
 
-        $this->addPhpIniRequirement('detect_unicode', false);
+        $this->addPhpConfigRequirement('detect_unicode', false);
 
         if (extension_loaded('suhosin')) {
-            $this->addPhpIniRequirement(
+            $this->addPhpConfigRequirement(
                 'suhosin.executor.include.whitelist',
                 create_function('$cfgValue', 'return false !== stripos($cfgValue, "phar");'),
                 false,
@@ -155,15 +155,15 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         if (extension_loaded('xdebug')) {
-            $this->addPhpIniRequirement(
+            $this->addPhpConfigRequirement(
                 'xdebug.show_exception_trace', false, true
             );
 
-            $this->addPhpIniRequirement(
+            $this->addPhpConfigRequirement(
                 'xdebug.scream', false, true
             );
 
-            $this->addPhpIniRecommendation(
+            $this->addPhpConfigRecommendation(
                 'xdebug.max_nesting_level',
                 create_function('$cfgValue', 'return $cfgValue > 100;'),
                 true,
@@ -181,7 +181,7 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         if (extension_loaded('mbstring')) {
-            $this->addPhpIniRequirement(
+            $this->addPhpConfigRequirement(
                 'mbstring.func_overload',
                 create_function('$cfgValue', 'return (int) $cfgValue === 0;'),
                 true,
@@ -319,7 +319,7 @@ class SymfonyRequirements extends RequirementCollection
                 }
             }
 
-            $this->addPhpIniRecommendation(
+            $this->addPhpConfigRecommendation(
                 'intl.error_level',
                 create_function('$cfgValue', 'return (int) $cfgValue === 0;'),
                 true,
@@ -356,13 +356,13 @@ class SymfonyRequirements extends RequirementCollection
             );
         }
 
-        $this->addPhpIniRecommendation('short_open_tag', false);
+        $this->addPhpConfigRecommendation('short_open_tag', false);
 
-        $this->addPhpIniRecommendation('magic_quotes_gpc', false, true);
+        $this->addPhpConfigRecommendation('magic_quotes_gpc', false, true);
 
-        $this->addPhpIniRecommendation('register_globals', false, true);
+        $this->addPhpConfigRecommendation('register_globals', false, true);
 
-        $this->addPhpIniRecommendation('session.auto_start', false);
+        $this->addPhpConfigRecommendation('session.auto_start', false);
 
         $this->addRecommendation(
             class_exists('PDO'),

--- a/web/check.php
+++ b/web/check.php
@@ -411,10 +411,10 @@ $hasMinorProblems = (bool) count($minorProblems);
                             </ol>
                         <?php endif; ?>
 
-                        <?php if ($symfonyRequirements->hasPhpIniConfigIssue()): ?>
+                        <?php if ($symfonyRequirements->hasPhpConfigIssue()): ?>
                             <p id="phpini">*
-                                <?php if ($symfonyRequirements->getPhpIniConfigPath()): ?>
-                                    Changes to the <strong>php.ini</strong> file must be done in "<strong><?php echo $symfonyRequirements->getPhpIniConfigPath() ?></strong>".
+                                <?php if ($symfonyRequirements->getPhpIniPath()): ?>
+                                    Changes to the <strong>php.ini</strong> file must be done in "<strong><?php echo $symfonyRequirements->getPhpIniPath() ?></strong>".
                                 <?php else: ?>
                                     To change settings, create a "<strong>php.ini</strong>".
                                 <?php endif; ?>


### PR DESCRIPTION
If you don't think it's worth it, it's OK to close this as "won't fix" 😄 

---

The `PhpIni*()` name looks wrong to me because instead of telling *what* it does (checking PHP config options) it tells *how* it does it (checking things in a file called `php.ini`).

Moreover, this is not true because we never look for things in a file called `php.ini`. We use the `ini_get()` function and the config options can be stored in lots of different small `*.ini` files (they usually are).